### PR TITLE
Add material naming format for svg icons

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -52,8 +52,8 @@ After installation, the `svgd` command will be available. Use it to generate con
 - **`-t, --template <string>`**  
   Template string for naming convention (default: an empty string).
 
-- **`-f, --format <format>`**  
-  Naming format. Options: `camelCase`, `PascalCase`, `snake_case`, `SCREAMING_SNAKE_CASE` (default: `camelCase`).
+- **`-f, --format <format>`**
+  Naming format. Options: `camelCase`, `PascalCase`, `snake_case`, `SCREAMING_SNAKE_CASE`, `material` (default: `camelCase`).
 
 - **`-m, --md <string>`**  
   Path to the output Markdown file (default: empty).

--- a/packages/cli/src/parseCliArgs.ts
+++ b/packages/cli/src/parseCliArgs.ts
@@ -9,7 +9,7 @@ export interface CLIOptions {
     colors?: boolean;
     quote: boolean;
     template: string;
-    format: 'camelCase' | 'PascalCase' | 'snake_case' | 'SCREAMING_SNAKE_CASE';
+    format: 'camelCase' | 'PascalCase' | 'snake_case' | 'SCREAMING_SNAKE_CASE' | 'material';
     md?: string;
     html?: string;
     dts?: boolean;
@@ -44,7 +44,7 @@ export function parseCliArgs(argv: string[]): CLIOptions {
         .option('-d, --dts', 'Path to the output HTML file', false)
         .option(
             '-f, --format <format>',
-            'Naming format: camelCase, PascalCase, snake_case, or SCREAMING_SNAKE_CASE',
+            'Naming format: camelCase, PascalCase, snake_case, SCREAMING_SNAKE_CASE, or material',
             'camelCase'
         )
         .parse(argv);

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -90,6 +90,7 @@ Generates a formatted constant name from a file path. Accepts a base directory, 
 - `PascalCase`
 - `snake_case`
 - `SCREAMING_SNAKE_CASE`
+- `material`
 
 **Usage:**
 
@@ -473,7 +474,28 @@ export const constantName = generateConstantName(filePath, baseDir, template, fo
 }
 ```
 
-#### **Use Case 5: Template `{-2}{1,-3}{-1}`**
+#### **Use Case 5: material Format**
+
+**Code:**
+
+```ts
+import { generateConstantName } from "@svgd/utils";
+const filePath = "src/3d_rotation_24px.svg";
+const baseDir = "src";
+const template = "";
+const format = "material";
+export const constantName = generateConstantName(filePath, baseDir, template, format);
+```
+
+**Result:**
+
+```json
+{
+  "constantName": "ThreeDRotation"
+}
+```
+
+#### **Use Case 6: Template `{-2}{1,-3}{-1}`**
 
 **Code:**
 
@@ -494,7 +516,7 @@ export const constantName = generateConstantName(filePath, baseDir, template, fo
 }
 ```
 
-#### **Use Case 6: Template `{1,2}`**
+#### **Use Case 7: Template `{1,2}`**
 
 **Code:**
 
@@ -515,7 +537,7 @@ export const constantName = generateConstantName(filePath, baseDir, template, fo
 }
 ```
 
-#### **Use Case 7: Template `{0,0}`**
+#### **Use Case 8: Template `{0,0}`**
 
 **Code:**
 
@@ -536,7 +558,7 @@ export const constantName = generateConstantName(filePath, baseDir, template, fo
 }
 ```
 
-#### **Use Case 8: Template `{-1}` (Negative Index)**
+#### **Use Case 9: Template `{-1}` (Negative Index)**
 
 **Code:**
 

--- a/packages/utils/docs/code.md
+++ b/packages/utils/docs/code.md
@@ -1,4 +1,57 @@
+I will provide the source code of my project. Please analyze the code structure and help me extend the functionality when I ask.
+All code and comments must be in English. Please follow the style and conventions used in the existing codebase.
+For react project use version 18 and 19 versions (with jsx-runtime style).
+Also use Clean Code, Clean Architecture, SOLID, Atomic design
+If something is unclear or needs clarification, feel free to ask me.
 # Project "@svgd/utils"
+
+## package.json
+
+```json
+{
+  "name": "@svgd/utils",
+  "version": "0.1.30",
+  "description": "Utility functions to convert SVG to path d.",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run tests/stories/stories.test.ts",
+    "docs": "tsx scripts/codeDoc && tsx scripts/useCasesDoc",
+    "lint": "eslint"
+  },
+  "author": "",
+  "license": "MIT",
+  "private": false,
+  "devDependencies": {
+    "@svgd/mocks": "*",
+    "@types/node": "^18.19.71",
+    "codools": "^0.2.17",
+    "tsup": "^8.3.5",
+    "tsx": "^4.19.2",
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^3.0.5"
+  },
+  "dependencies": {
+    "@svgd/core": "^0.3.27",
+    "sharp": "^0.33.5",
+    "svgo": "^3.3.2",
+    "typescript": "^5.7.3"
+  }
+}
+
+```
 
 ## tsconfig.json
 
@@ -30,55 +83,7 @@
 
 ```
 
-## package.json
-
-```json
-{
-  "name": "@svgd/utils",
-  "version": "0.1.12",
-  "description": "Utility functions to convert SVG to path d.",
-  "type": "module",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
-    }
-  },
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "tsup",
-    "test": "vitest run tests/stories/stories.test.ts",
-    "docs": "tsx scripts/codeDoc && tsx scripts/useCasesDoc",
-    "lint": "eslint"
-  },
-  "author": "",
-  "license": "MIT",
-  "private": false,
-  "devDependencies": {
-    "@svgd/mocks": "*",
-    "@types/node": "^18.19.71",
-    "codools": "^0.2.1",
-    "tsup": "^8.3.5",
-    "tsx": "^4.19.2",
-    "vite-tsconfig-paths": "^5.1.4",
-    "vitest": "^3.0.5"
-  },
-  "dependencies": {
-    "@svgd/core": "^0.3.10",
-    "sharp": "^0.33.5",
-    "svgo": "^3.3.2",
-    "typescript": "^5.7.3"
-  }
-}
-
-```
-
-## src\getPng.ts
+## src/getPng.ts
 
 ```typescript
 import sharp from "sharp";
@@ -94,7 +99,8 @@ export const getPng = async (svgContent: string, width = 64, height = width) => 
 
 ```
 
-## src\getSvgFileNames.ts
+
+## src/getSvgFileNames.ts
 
 ```typescript
 import { readdirSync } from "fs";
@@ -105,11 +111,13 @@ export function getSvgFileNames(dir: string): string[] {
     return entries
         .filter((entry) => /\.(svg)$/i.test(entry.name) && !entry.isDirectory())
         .map(({ name, parentPath }) => join(parentPath, name))
+        .sort()
 }
 
 ```
 
-## src\index.ts
+
+## src/index.ts
 
 ```typescript
 import { getSvgoConfig, getSvg, defaultConfig, type SVGDConfig } from "@svgd/core";
@@ -139,7 +147,8 @@ export type {
 
 ```
 
-## src\nameFormat.ts
+
+## src/nameFormat.ts
 
 ```typescript
 import path from 'path';
@@ -342,7 +351,8 @@ export function generateFileName(filePath: string, baseDir: string, template: st
 
 ```
 
-## src\parseSvg.ts
+
+## src/parseSvg.ts
 
 ```typescript
 import { type Config, optimize } from 'svgo';

--- a/packages/utils/docs/code.md
+++ b/packages/utils/docs/code.md
@@ -149,6 +149,7 @@ export const NameFormats = {
     PascalCase: 'PascalCase',
     snake_case: 'snake_case',
     SCREAMING_SNAKE_CASE: 'SCREAMING_SNAKE_CASE',
+    material: 'material',
 } as const;
 
 export type NameFormat = typeof NameFormats[keyof typeof NameFormats];
@@ -169,6 +170,94 @@ function toPascalCase(str: string): string {
 function toCamelCase(str: string): string {
     // Example: "MyIconName" -> "myIconName"
     return toPascalCase(str).replace(/^[A-Z]/, (match) => match.toLowerCase());
+}
+
+const singleDigitNumbers = [
+    'Zero',
+    'One',
+    'Two',
+    'Three',
+    'Four',
+    'Five',
+    'Six',
+    'Seven',
+    'Eight',
+    'Nine',
+];
+
+const twoDigitNumbers1 = [
+    'Ten',
+    'Eleven',
+    'Twelve',
+    'Thirteen',
+    'Fourteen',
+    'Fifteen',
+    'Sixteen',
+    'Seventeen',
+    'Eighteen',
+    'Nineteen',
+];
+
+function toMaterialName(str: string): string {
+    let fileName = str
+        .replace(/_([0-9]+)px$/, '')
+        .replace(/(^.)|(_)(.)/g, (_m, p1, _p2, p3) => (p1 || p3).toUpperCase());
+
+    if (fileName.startsWith('3dRotation')) {
+        return `ThreeD${fileName.slice(2)}`;
+    }
+
+    if (fileName.startsWith('3p')) {
+        return `ThreeP${fileName.slice(2)}`;
+    }
+
+    if (fileName.startsWith('30fps')) {
+        return `ThirtyFps${fileName.slice(5)}`;
+    }
+    if (fileName.startsWith('60fps')) {
+        return `SixtyFps${fileName.slice(5)}`;
+    }
+    if (fileName.startsWith('360')) {
+        return `ThreeSixty${fileName.slice(3)}`;
+    }
+
+    if (/\dFt/.test(fileName)) {
+        return `${singleDigitNumbers[Number(fileName[0])] ?? fileName[0]}${fileName.slice(1)}`;
+    }
+
+    if (/\dk/.test(fileName)) {
+        return `${singleDigitNumbers[Number(fileName[0])] ?? fileName[0]}K${fileName.slice(2)}`;
+    }
+
+    if (/^\dmp/.test(fileName)) {
+        return `${singleDigitNumbers[Number(fileName[0])] ?? fileName[0]}M${fileName.slice(2)}`;
+    }
+    if (/^1\dmp/.test(fileName)) {
+        return `${twoDigitNumbers1[Number(fileName[1])] ?? fileName[1]}M${fileName.slice(3)}`;
+    }
+    if (/^2\dmp/.test(fileName)) {
+        return `Twenty${singleDigitNumbers[Number(fileName[1])] ?? fileName[1]}M${fileName.slice(3)}`;
+    }
+
+    if (fileName.startsWith('1x')) {
+        return `TimesOne${fileName.slice(2)}`;
+    }
+
+    if (fileName.startsWith('3g')) {
+        return `ThreeG${fileName.slice(2)}`;
+    }
+    if (fileName.startsWith('4g')) {
+        return `FourG${fileName.slice(2)}`;
+    }
+    if (fileName.startsWith('5g')) {
+        return `FiveG${fileName.slice(2)}`;
+    }
+
+    if (/^1\d/.test(fileName)) {
+        return `${twoDigitNumbers1[Number(fileName[1])] ?? fileName[1]}${fileName.slice(2)}`;
+    }
+
+    return fileName;
 }
 
 /**
@@ -230,6 +319,8 @@ export function generateConstantName(
             return formatted.replace(/[-\s]+/g, '_').toLowerCase();
         case NameFormats.SCREAMING_SNAKE_CASE:
             return formatted.replace(/[-\s]+/g, '_').toUpperCase();
+        case NameFormats.material:
+            return toMaterialName(formatted);
         default:
             return formatted;
     }

--- a/packages/utils/docs/stories.md
+++ b/packages/utils/docs/stories.md
@@ -480,7 +480,26 @@ export const constantName = generateConstantName(filePath, baseDir, template, fo
 }
 ```
 
-### Use Case 5. Template {-2}{1,-3}{-1}
+### Use Case 5. Format material
+
+#### Code:
+```ts
+import { generateConstantName } from "@svgd/utils";
+const filePath = "src/3d_rotation_24px.svg";
+const baseDir = "src";
+const template = "";
+const format = "material";
+export const constantName = generateConstantName(filePath, baseDir, template, format);
+
+```
+
+#### Result:
+```json
+{
+  "constantName": "ThreeDRotation"
+}
+```
+### Use Case 6. Template {-2}{1,-3}{-1}
 
 #### Code:
 ```ts
@@ -500,7 +519,7 @@ export const constantName = generateConstantName(filePath, baseDir, template, fo
 }
 ```
 
-### Use Case 6. Template {1,2}
+### Use Case 7. Template {1,2}
 
 #### Code:
 ```ts
@@ -520,7 +539,7 @@ export const constantName = generateConstantName(filePath, baseDir, template, fo
 }
 ```
 
-### Use Case 7. Template {0,0}
+### Use Case 8. Template {0,0}
 
 #### Code:
 ```ts
@@ -540,7 +559,7 @@ export const constantName = generateConstantName(filePath, baseDir, template, fo
 }
 ```
 
-### Use Case 8. Template {-1} (Negative index)
+### Use Case 9. Template {-1} (Negative index)
 
 #### Code:
 ```ts

--- a/packages/utils/docs/stories.md
+++ b/packages/utils/docs/stories.md
@@ -480,7 +480,7 @@ export const constantName = generateConstantName(filePath, baseDir, template, fo
 }
 ```
 
-### Use Case 5. Format material
+### Use Case 5. Format material (3d_rotation)
 
 #### Code:
 ```ts
@@ -499,6 +499,7 @@ export const constantName = generateConstantName(filePath, baseDir, template, fo
   "constantName": "ThreeDRotation"
 }
 ```
+
 ### Use Case 6. Template {-2}{1,-3}{-1}
 
 #### Code:
@@ -700,10 +701,10 @@ export const svgFileNames = getSvgFileNames(filePath);
   "svgFileNames": [
     "C:\\work\\svg\\svgd\\packages\\mocks\\inputIcons\\fill-none.svg",
     "C:\\work\\svg\\svgd\\packages\\mocks\\inputIcons\\rule-even-odd.svg",
-    "C:\\work\\svg\\svgd\\packages\\mocks\\inputIcons\\test_icon.svg",
     "C:\\work\\svg\\svgd\\packages\\mocks\\inputIcons\\subdir1\\icon1_20px.svg",
     "C:\\work\\svg\\svgd\\packages\\mocks\\inputIcons\\subdir1\\icon1_24px.svg",
-    "C:\\work\\svg\\svgd\\packages\\mocks\\inputIcons\\subdir1\\subdir2\\icon5_24px.svg"
+    "C:\\work\\svg\\svgd\\packages\\mocks\\inputIcons\\subdir1\\subdir2\\icon5_24px.svg",
+    "C:\\work\\svg\\svgd\\packages\\mocks\\inputIcons\\test_icon.svg"
   ]
 }
 ```

--- a/packages/utils/src/nameFormat.ts
+++ b/packages/utils/src/nameFormat.ts
@@ -5,6 +5,7 @@ export const NameFormats = {
     PascalCase: 'PascalCase',
     snake_case: 'snake_case',
     SCREAMING_SNAKE_CASE: 'SCREAMING_SNAKE_CASE',
+    material: 'material',
 } as const;
 
 export type NameFormat = typeof NameFormats[keyof typeof NameFormats];
@@ -25,6 +26,94 @@ function toPascalCase(str: string): string {
 function toCamelCase(str: string): string {
     // Example: "MyIconName" -> "myIconName"
     return toPascalCase(str).replace(/^[A-Z]/, (match) => match.toLowerCase());
+}
+
+const singleDigitNumbers = [
+    'Zero',
+    'One',
+    'Two',
+    'Three',
+    'Four',
+    'Five',
+    'Six',
+    'Seven',
+    'Eight',
+    'Nine',
+];
+
+const twoDigitNumbers1 = [
+    'Ten',
+    'Eleven',
+    'Twelve',
+    'Thirteen',
+    'Fourteen',
+    'Fifteen',
+    'Sixteen',
+    'Seventeen',
+    'Eighteen',
+    'Nineteen',
+];
+
+function toMaterialName(str: string): string {
+    let fileName = str
+        .replace(/_([0-9]+)px$/, '')
+        .replace(/(^.)|(_)(.)/g, (_m, p1, _p2, p3) => (p1 || p3).toUpperCase());
+
+    if (fileName.startsWith('3dRotation')) {
+        return `ThreeD${fileName.slice(2)}`;
+    }
+
+    if (fileName.startsWith('3p')) {
+        return `ThreeP${fileName.slice(2)}`;
+    }
+
+    if (fileName.startsWith('30fps')) {
+        return `ThirtyFps${fileName.slice(5)}`;
+    }
+    if (fileName.startsWith('60fps')) {
+        return `SixtyFps${fileName.slice(5)}`;
+    }
+    if (fileName.startsWith('360')) {
+        return `ThreeSixty${fileName.slice(3)}`;
+    }
+
+    if (/\dFt/.test(fileName)) {
+        return `${singleDigitNumbers[Number(fileName[0])] ?? fileName[0]}${fileName.slice(1)}`;
+    }
+
+    if (/\dk/.test(fileName)) {
+        return `${singleDigitNumbers[Number(fileName[0])] ?? fileName[0]}K${fileName.slice(2)}`;
+    }
+
+    if (/^\dmp/.test(fileName)) {
+        return `${singleDigitNumbers[Number(fileName[0])] ?? fileName[0]}M${fileName.slice(2)}`;
+    }
+    if (/^1\dmp/.test(fileName)) {
+        return `${twoDigitNumbers1[Number(fileName[1])] ?? fileName[1]}M${fileName.slice(3)}`;
+    }
+    if (/^2\dmp/.test(fileName)) {
+        return `Twenty${singleDigitNumbers[Number(fileName[1])] ?? fileName[1]}M${fileName.slice(3)}`;
+    }
+
+    if (fileName.startsWith('1x')) {
+        return `TimesOne${fileName.slice(2)}`;
+    }
+
+    if (fileName.startsWith('3g')) {
+        return `ThreeG${fileName.slice(2)}`;
+    }
+    if (fileName.startsWith('4g')) {
+        return `FourG${fileName.slice(2)}`;
+    }
+    if (fileName.startsWith('5g')) {
+        return `FiveG${fileName.slice(2)}`;
+    }
+
+    if (/^1\d/.test(fileName)) {
+        return `${twoDigitNumbers1[Number(fileName[1])] ?? fileName[1]}${fileName.slice(2)}`;
+    }
+
+    return fileName;
 }
 
 /**
@@ -86,6 +175,8 @@ export function generateConstantName(
             return formatted.replace(/[-\s]+/g, '_').toLowerCase();
         case NameFormats.SCREAMING_SNAKE_CASE:
             return formatted.replace(/[-\s]+/g, '_').toUpperCase();
+        case NameFormats.material:
+            return toMaterialName(formatted);
         default:
             return formatted;
     }

--- a/packages/utils/tests/stories/generateConstantName/stories.ts
+++ b/packages/utils/tests/stories/generateConstantName/stories.ts
@@ -39,6 +39,14 @@ const mocks = [
     constantName: "ICONS_GROUP1_SUBGROUP1_SIZE24_HOME"
   },
   {
+    filePath: "src/3d_rotation_24px.svg",
+    baseDir: "src",
+    template: "",
+    format: NameFormats.material,
+    title: "Format material (3d_rotation)",
+    constantName: "ThreeDRotation"
+  },
+  {
     ...commonValues,
     title: "Template {-2}{1,-3}{-1}",
     template: "{-2}{1,-3}{-1}",


### PR DESCRIPTION
## Summary
- implement `material` format matching MUI's naming rules
- update CLI to support the new format
- document the new option in CLI and utils readme
- provide example and documentation for material format
- test `generateConstantName` with material format

## Testing
- `npm test` *(fails: Failed to resolve package "codools")*


------
https://chatgpt.com/codex/tasks/task_e_686ab71f147c832b99cda7d2f2fd942a