### PR TITLE
docs(cli): add npm badge and keywords

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,8 @@
 # @svgd/cli
 
-A CLI tool to generate constants from SVG files. It parses SVG assets, extracts path data (and more), and produces exportable constants in various formats (JavaScript, TypeScript, Markdown, HTML). Use it both via the command line and programmatically in your projects.
+[![](https://img.shields.io/npm/v/@svgd/cli?style=flat)](https://www.npmjs.com/package/@svgd/cli)
+
+A command-line tool for generating constants from SVG assets. It parses SVG files to extract path data and more, then produces exportable constants in JavaScript, TypeScript, Markdown, and HTML formats. Use it via the CLI or programmatically in your projects.
 
 ---
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,6 +46,11 @@
     "svg",
     "svgd",
     "cli",
+    "icons",
+    "svg icons",
+    "svg sprite",
+    "svg path d",
+    "svgo",
     "icon-generator",
     "constants"
   ]

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@svgd/cli",
   "version": "1.0.29",
-  "description": "CLI tool to generate constants from SVG files",
+  "description": "Command-line utility for generating constants from SVG assets",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
@@ -41,5 +41,12 @@
   "dependencies": {
     "@svgd/utils": "^0.1.32",
     "commander": "^12.1.0"
-  }
+  },
+  "keywords": [
+    "svg",
+    "svgd",
+    "cli",
+    "icon-generator",
+    "constants"
+  ]
 }


### PR DESCRIPTION
## Summary
- improve @svgd/cli description and add keywords in package.json
- show npm version badge in README

## Testing
- `npm test` *(fails: failed to resolve package "codools")*


------
https://chatgpt.com/codex/tasks/task_e_687ce4fd2c9c832bb59c758745dc4bd0